### PR TITLE
allow for command-line arguments to tox

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,5 @@ flake8 >= 3.3.0
 pep8-naming >= 0.4.1
 flake8-quotes >= 0.8.1
 flake8-import-order >= 0.9.0
+pylint
 Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
     # Use -bb to enable BytesWarnings as error to catch str/bytes misuse.
     # Use -Werror to treat warnings as errors.
-    python -bb -Werror -m pytest --cov="{envsitepackagesdir}/fact"
+    python -bb -Werror -m pytest --cov="{envsitepackagesdir}/fact" {posargs}
 
 [testenv:coverage]
 skip_install = true
@@ -58,9 +58,11 @@ commands =
 skip_install = true
 setenv =
 deps =
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
 commands =
     flake8 src tests
+    pylint src tests
 
 [testenv:docs]
 skip_install = true


### PR DESCRIPTION
validate code with pylint as well

e.g., tox -e py36 -- -vvs