### PR TITLE
Magic variable envsitepackagesdir is not necessary

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     # Use -bb to enable BytesWarnings as error to catch str/bytes misuse.
     # Use -Werror to treat warnings as errors.
     {envpython} -bb -Werror -m pytest \
-        --cov="{envsitepackagesdir}/fact" --cov-report=html --cov-report=term {posargs}
+        --cov=fact --cov-report=html --cov-report=term {posargs}
 
 [testenv:type-check]
 skip_install = true


### PR DESCRIPTION
Apparently, coverage can take a module name instead of a full path to the files. This obviates the need for the tox magic variable `envsitepackagesdir`, which is not always the path to the module anyway (e.g. the module is imported from the current working directory).