### PR TITLE
Upgrade dev-requirements and pip-tools instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ To update dependencies:
 .. code-block:: bash
 
     (venv) $ python -m pip install pip-tools
-    (venv) $ pip-compile --upgrade
-    (venv) $ pip-compile --upgrade dev-requirements.in
+    (venv) $ python -m piptools compile --upgrade
+    (venv) $ python -m piptools compile --upgrade dev-requirements.in
 
 After upgrading dependencies, run the unit tests as described in the `Unit Testing`_ section
 to ensure that none of the updated packages caused incompatibilities in the current project.
@@ -110,7 +110,7 @@ To cleanly install your dependencies into your virtual environment:
 
 .. code-block:: bash
 
-    (venv) $ pip-sync requirements.txt dev-requirements.txt
+    (venv) $ python -m piptools sync requirements.txt dev-requirements.txt
 
 Packaging
 ---------
@@ -164,7 +164,8 @@ PEP8 style guide checking, and documentation generation.
 
     # Run all environments.
     #   To only run a single environment, specify it like: -e lint
-    # Note: tox is installed into the virtual environment automatically by pip-sync command above.
+    # Note: tox is installed into the virtual environment automatically by ``piptools sync``
+    # command above.
     (venv) $ tox
 
 Unit Testing
@@ -274,8 +275,8 @@ To generate the Sphinx project shown in this project:
 
 .. code-block:: bash
 
-    # Note: Sphinx is installed into the virtual environment automatically by pip-sync command
-    # above.
+    # Note: Sphinx is installed into the virtual environment automatically by ``piptools sync``
+    # command above.
     (venv) $ mkdir docs
     (venv) $ cd docs
     (venv) $ sphinx-quickstart --no-makefile --no-batchfile --extensions sphinx.ext.napoleon

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,3 +1,6 @@
+# Constrain dev-requirements by requirements to avoid clashing requirements.
+-c requirements.txt
+
 tox
 
 # Testing.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,60 +4,144 @@
 #
 #    pip-compile dev-requirements.in
 #
-alabaster==0.7.12         # via sphinx
-appdirs==1.4.4            # via black, virtualenv
-atomicwrites==1.4.0       # via pytest
-attrs==20.2.0             # via pytest
-babel==2.8.0              # via sphinx
-black==20.8b1             # via -r dev-requirements.in
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
-click==7.1.2              # via black
-colorama==0.4.4           # via pytest, sphinx, tox
-coverage==5.3             # via pytest-cov
-distlib==0.3.1            # via virtualenv
-docutils==0.16            # via sphinx
-filelock==3.0.12          # via tox, virtualenv
-flake8-polyfill==1.0.2    # via pep8-naming
-flake8==3.8.4             # via -r dev-requirements.in, flake8-polyfill
-idna==2.10                # via requests
-imagesize==1.2.0          # via sphinx
-iniconfig==1.1.1          # via pytest
-isort==5.6.4              # via -r dev-requirements.in
-jinja2==2.11.2            # via sphinx
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-mypy-extensions==0.4.3    # via black, mypy
-mypy==0.790               # via -r dev-requirements.in
-packaging==20.4           # via pytest, sphinx, tox
-pathspec==0.8.0           # via black
-pep8-naming==0.11.1       # via -r dev-requirements.in
-pluggy==0.13.1            # via pytest, tox
-py==1.9.0                 # via pytest, tox
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pygments==2.7.2           # via sphinx
-pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.1        # via -r dev-requirements.in
-pytest==6.1.2             # via -r dev-requirements.in, pytest-cov
-pytz==2020.1              # via babel
-regex==2020.10.28         # via black
-requests==2.24.0          # via sphinx
-six==1.15.0               # via packaging, tox, virtualenv
-snowballstemmer==2.0.0    # via sphinx
-sphinx==3.2.1             # via -r dev-requirements.in
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-toml==0.10.1              # via black, pytest, tox
-tox==3.20.1               # via -r dev-requirements.in
-typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.3  # via black, mypy
-urllib3==1.25.11          # via requests
-virtualenv==20.1.0        # via tox
+alabaster==0.7.12
+    # via sphinx
+appdirs==1.4.4
+    # via
+    #   black
+    #   virtualenv
+atomicwrites==1.4.0
+    # via pytest
+attrs==20.3.0
+    # via pytest
+babel==2.9.0
+    # via sphinx
+black==20.8b1
+    # via -r dev-requirements.in
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+click==7.1.2
+    # via black
+colorama==0.4.4
+    # via
+    #   -c requirements.txt
+    #   pytest
+    #   sphinx
+    #   tox
+coverage==5.5
+    # via pytest-cov
+distlib==0.3.1
+    # via virtualenv
+docutils==0.16
+    # via sphinx
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+flake8-polyfill==1.0.2
+    # via pep8-naming
+flake8==3.8.4
+    # via
+    #   -r dev-requirements.in
+    #   flake8-polyfill
+idna==2.10
+    # via requests
+imagesize==1.2.0
+    # via sphinx
+iniconfig==1.1.1
+    # via pytest
+isort==5.7.0
+    # via -r dev-requirements.in
+jinja2==2.11.3
+    # via sphinx
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
+mypy==0.812
+    # via -r dev-requirements.in
+packaging==20.9
+    # via
+    #   pytest
+    #   sphinx
+    #   tox
+pathspec==0.8.1
+    # via black
+pep8-naming==0.11.1
+    # via -r dev-requirements.in
+pluggy==0.13.1
+    # via
+    #   pytest
+    #   tox
+py==1.10.0
+    # via
+    #   pytest
+    #   tox
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pygments==2.8.0
+    # via sphinx
+pyparsing==2.4.7
+    # via packaging
+pytest-cov==2.11.1
+    # via -r dev-requirements.in
+pytest==6.2.2
+    # via
+    #   -r dev-requirements.in
+    #   pytest-cov
+pytz==2021.1
+    # via babel
+regex==2020.11.13
+    # via black
+requests==2.25.1
+    # via sphinx
+six==1.15.0
+    # via
+    #   tox
+    #   virtualenv
+snowballstemmer==2.1.0
+    # via sphinx
+sphinx==3.5.1
+    # via -r dev-requirements.in
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+toml==0.10.2
+    # via
+    #   black
+    #   pytest
+    #   tox
+tox==3.23.0
+    # via -r dev-requirements.in
+typed-ast==1.4.2
+    # via
+    #   black
+    #   mypy
+typing-extensions==3.7.4.3
+    # via
+    #   black
+    #   mypy
+urllib3==1.26.3
+    # via requests
+virtualenv==20.4.2
+    # via tox
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-colorama==0.4.4           # via -r requirements.in
-exitstatus==2.0.1         # via -r requirements.in
+colorama==0.4.4
+    # via -r requirements.in
+exitstatus==2.1.0
+    # via -r requirements.in


### PR DESCRIPTION
- Follow [`pip-tools`](https://github.com/jazzband/pip-tools) advice to constrain `dev-requirements.in`.
- Use `python -m piptools ...` command to avoid issues where `pip-tools` is run outside the current `venv`
- Upgrade `dev-requirements`
