### PR TITLE
Remove need for empty site_url

### DIFF
--- a/docs/user_guide/mkdocs.yml
+++ b/docs/user_guide/mkdocs.yml
@@ -27,9 +27,6 @@ extra:
       link: https://github.com/johnthagen/python-blueprint
 # This is needed to allow links to work when opened from the file system.
 use_directory_urls: false
-# If building the docs in an agnostic way where it is not known what the final
-# hosting URL will be, set this to empty string.
-site_url: ""
 plugins:
   - search
   # This plugin is used to validate URLs (including some anchors).


### PR DESCRIPTION
MkDocs 1.2.2 removed the need for a blank `site_url`.

- https://github.com/mkdocs/mkdocs/pull/2490