### PR TITLE
Update documentation with Material for MkDocs 8 features

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and a command line interface (`fact.cli`).
 
 # Requirements
 
-Python 3.7+.
+Python 3.8+.
 
 > **Note**
 >

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -27,7 +27,3 @@ isort
 mkdocs-material
 mkdocs-htmlproofer-plugin
 mkdocstrings
-
-# TODO: Remove this once flake8 remove cap on importlib-metadata, or Python 3.7 support is dropped.
-# https://github.com/PyCQA/flake8/commit/975a3f45334861ebd8960c00e881443c23654bca
-importlib-metadata<4.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,15 +8,15 @@ atomicwrites==1.4.0
     # via pytest
 attrs==21.2.0
     # via pytest
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 beautifulsoup4==4.10.0
     # via mkdocs-htmlproofer-plugin
-black==21.9b0
+black==21.11b1
     # via -r .\dev-requirements.in
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via requests
 click==8.0.3
     # via
@@ -29,11 +29,11 @@ colorama==0.4.4
     #   click
     #   pytest
     #   tox
-coverage[toml]==6.0.2
+coverage[toml]==6.2
     # via pytest-cov
 distlib==0.3.3
     # via virtualenv
-filelock==3.3.1
+filelock==3.4.0
     # via
     #   tox
     #   virtualenv
@@ -48,22 +48,22 @@ ghp-import==2.0.2
     # via mkdocs
 idna==3.3
     # via requests
-importlib-metadata==4.2.0
+importlib-metadata==4.8.2
     # via
-    #   -r .\dev-requirements.in
+    #   markdown
     #   mkdocs
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
+isort==5.10.1
     # via -r .\dev-requirements.in
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   mkdocs
     #   mkdocs-material
     #   mkdocstrings
-lxml==4.6.3
+lxml==4.6.4
     # via mkdocs-htmlproofer-plugin
-markdown==3.3.4
+markdown==3.3.6
     # via
     #   mkdocs
     #   mkdocs-autorefs
@@ -89,7 +89,7 @@ mkdocs-autorefs==0.3.0
     # via mkdocstrings
 mkdocs-htmlproofer-plugin==0.7.0
     # via -r .\dev-requirements.in
-mkdocs-material==7.3.4
+mkdocs-material==8.0.0
     # via -r .\dev-requirements.in
 mkdocs-material-extensions==1.0.3
     # via mkdocs-material
@@ -101,7 +101,7 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-packaging==21.0
+packaging==21.3
     # via
     #   mkdocs
     #   pytest
@@ -118,7 +118,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-py==1.10.0
+py==1.11.0
     # via
     #   pytest
     #   tox
@@ -128,11 +128,11 @@ pyflakes==2.4.0
     # via flake8
 pygments==2.10.0
     # via mkdocs-material
-pymdown-extensions==9.0
+pymdown-extensions==9.1
     # via
     #   mkdocs-material
     #   mkdocstrings
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via
@@ -150,7 +150,7 @@ pyyaml==6.0
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2021.10.8
+regex==2021.11.10
     # via black
 requests==2.26.0
     # via mkdocs-htmlproofer-plugin
@@ -159,26 +159,26 @@ six==1.16.0
     #   python-dateutil
     #   tox
     #   virtualenv
-soupsieve==2.2.1
+soupsieve==2.3.1
     # via beautifulsoup4
 toml==0.10.2
     # via
     #   mypy
     #   pytest
     #   tox
-tomli==1.2.1
+tomli==1.2.2
     # via
     #   black
     #   coverage
 tox==3.24.4
     # via -r .\dev-requirements.in
-typing-extensions==3.10.0.2
+typing-extensions==4.0.0
     # via
     #   black
     #   mypy
 urllib3==1.26.7
     # via requests
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via tox
 watchdog==2.1.6
     # via mkdocs

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
     This user guide is purely an illustrative example that shows off several features of MkDocs
     and included Markdown extensions.
 
-## Installation 
+## Installation
 
 First, create and activate a Python virtual environment:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,27 +10,27 @@
     This user guide is purely an illustrative example that shows off several features of MkDocs
     and included Markdown extensions.
 
-## Installation
+## Installation 
 
 First, create and activate a Python virtual environment:
 
 === "Linux/macOS"
 
-    ```
+    ```bash
     python3 -m venv venv
     source venv/bin/activate
     ```
 
 === "Windows"
 
-    ```
+    ```powershell
     py -m venv venv
     venv\Scripts\activate
     ```
 
 Then install the `fact` package:
 
-```
+```bash
 pip install .
 ```
 
@@ -41,8 +41,11 @@ To use `fact` within your project, import the `factorial` function and execute i
 ```python
 from fact.lib import factorial
 
+# (1)
 assert factorial(3) == 6
 ```
+
+1. This assertion will be `True`
 
 !!! tip
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
     repo: fontawesome/brands/github
   favicon: static/math-integral-box.png
   features:
+    - content.code.annotate
+    - navigation.tracking
     - search.highlight
     - search.share
     - search.suggest
@@ -24,7 +26,8 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
   - pymdownx.snippets
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     package_dir={"": "src"},
     # pip 9.0+ will inspect this field when installing to help users install a
     # compatible version of the library for their Python version.
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     # There are some peculiarities on how to include package data for source
     # distributions using setuptools. You also need to add entries for package
     # data to MANIFEST.in.
@@ -46,7 +46,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ extend-exclude =
 # This section is not needed if not using GitHub Actions for CI.
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39, fmt-check, lint, type-check, docs
     3.10: py310


### PR DESCRIPTION
- Material for MkDocs 8 new features: https://squidfunk.github.io/mkdocs-material/changelog/?h=ch#8.0.0
- Also drop Python 3.7 due to dependency conflict between `flake8` and `Markdown`: https://github.com/PyCQA/flake8/commit/975a3f45334861ebd8960c00e881443c23654bca