### PR TITLE
Include the Typing::Typed classifier in fully typed projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Typing :: Typed",
     ],
     entry_points={"console_scripts": ["fact=fact.cli:main"]},
 )


### PR DESCRIPTION
The `Typing :: Typed` [classifier](https://pypi.org/classifiers/) is available for projects that are fully typed. As this is `mypy` compliant, this classifier is appropriate.