### PR TITLE
Include Private PyPI classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Typing :: Typed",
+    # Include this classifier to prevent accidently publishing private code to PyPI.
+    #   https://pypi.org/classifiers/
+    "Private :: Do Not Upload",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Include example for using `"Private :: Do Not Upload"` trove classifier to avoid accidentally publishing private code to PyPI.

- https://pypi.org/classifiers/
- https://github.com/pypa/warehouse/pull/5440
- https://github.com/pypa/packaging.python.org/pull/1056