### PR TITLE
Install Poetry with pip instead of pipx in GitHub Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pipx install poetry
+        run: pip install poetry
       - name: Install all dependencies, including Nox
         run: poetry install
       - name: Test with Nox


### PR DESCRIPTION
Simplify GitHub Actions by simply using `pip` instead of `pipx` to install Poetry globally.