### PR TITLE
Add a footnote example to user guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,9 @@
 
     This user guide is purely an illustrative example that shows off several features of 
     [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) and included Markdown
-    extensions.
+    extensions[^1].
+
+[^1]: See `python-blueprint`'s `mkdocs.yml` for how to enable these features.
 
 ## Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ theme:
     - search.suggest
 markdown_extensions:
   - admonition
+  - footnotes
   - pymdownx.keys
   - pymdownx.highlight
   - pymdownx.superfences


### PR DESCRIPTION
Add an example footnote from Material for Mkdocs

 - https://squidfunk.github.io/mkdocs-material/reference/footnotes/