### PR TITLE
Always validate anchors within the Mkdocs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ To build the user guide, run,
 
 and open `docs/user_guide/site/index.html` using a web browser.
 
-To build the user guide, validating external URLs and anchor links, run:
+To build the user guide, additionally validating external URLs, run:
 
 ```bash
 (fact) $ nox -s docs_check_urls

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,9 +59,9 @@ plugins:
       nav_file: SUMMARY.md
   # This plugin is used to validate URLs (including anchors).
   - htmlproofer:
-      # This is not enabled by default because this requires network I/O to validate URLs, so it
-      # is inherently not exactly reproducible.
-      enabled: !ENV [ENABLED_HTMLPROOFER, False]
+      # This is not enabled by default because this requires network I/O, so it is inherently not
+      # exactly reproducible. For larger projects, this can also slow local build times.
+      validate_external_urls: !ENV [HTMLPROOFER_VALIDATE_EXTERNAL_URLS, False]
       raise_error: True
 site_name: fact
 copyright: Copyright &copy; 2018-2022 John Hagen

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def docs(s: Session) -> None:
 @session(venv_backend="none")
 def docs_check_urls(s: Session) -> None:
     # TODO: Replace dict merge with d1 | d2 when dropping support for Python 3.8.
-    s.run("mkdocs", "build", env={**doc_env, **{"ENABLED_HTMLPROOFER": str(True)}})
+    s.run("mkdocs", "build", env={**doc_env, **{"HTMLPROOFER_VALIDATE_EXTERNAL_URLS": str(True)}})
 
 
 @session(venv_backend="none")


### PR DESCRIPTION
Follow on to #130 

Always validate anchors, which is fast and repeatable, for all `docs` builds. Continue to special case external URLs, which are slow and cannot be guaranteed to be reproducible.