### PR TITLE
Fix test session dependencies not being locked

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
           - { nox-session: fmt_check, poetry-groups: "fmt" }
           - { nox-session: lint, poetry-groups: "lint" }
           # type_check needs main and test dependencies for inline type annotations.
-          - { nox-session: type_check, poetry-groups: "type_check,main,test" }
+          - { nox-session: type_check, poetry-groups: "type_check,main,dev" }
           - { nox-session: docs, poetry-groups: "docs" }
     steps:
       - uses: actions/checkout@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -1329,4 +1329,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8, <3.12"
-content-hash = "73b8ea8b22997cfca3856f2a777f0199c201714bc78cbae8aae22cb1a04e1a0c"
+content-hash = "aa5de49fa5f444fa319fe2bf33c57597cbf17fc6f911f8d09c7b955691a2e8e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ typer = { version = "*", extras = ["all"] }
 [tool.poetry.group.nox.dependencies]
 nox-poetry = "*"
 
-[tool.poetry.group.test.dependencies]
+# TODO: Rename this to the "test" group when nox-poetry gains support for Poetry dependency
+#   groups. https://github.com/cjolowicz/nox-poetry/issues/663
+[tool.poetry.group.dev.dependencies]
 pytest = "*"
 pytest-cov = "*"
 


### PR DESCRIPTION
The `test` Nox session dependencies are not being properly locked. This is because `nox-poetry` does not yet support dependency groups:

- https://github.com/cjolowicz/nox-poetry/issues/663

This bug is due to #121 eagerly moving the test dependencies out of the `dev` group into the `test` group. The result of this, is that none of the test dependencies were being constrained by `nox-poetry` 🤦 .