### PR TITLE
Enable additional Material for Mkdocs navigation features

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,10 @@ theme:
     - content.code.annotate
     - content.code.copy
     - content.tabs.link
+    - navigation.expand
+    - navigation.instant
     - navigation.footer
+    - navigation.top
     - navigation.tracking
     - search.highlight
     - search.share


### PR DESCRIPTION
Follow on to

- #152

Enable additional navigation features that have existed in previous versions of Material for Mkdocs

- https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation