### PR TITLE
Enable strict pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,10 @@ skip_gitignore = true
 # isort defaults for skip to remain without the need to duplicate them.
 
 [tool.pytest.ini_options]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+]
 filterwarnings = [
     # When running tests, treat warnings as errors (e.g. -Werror).
     # See: https://docs.pytest.org/en/latest/reference/reference.html#confval-filterwarnings


### PR DESCRIPTION
```
  --strict-config       Any warnings encountered while parsing the `pytest` section of the configuration file raise errors
  --strict-markers      Markers not registered in the `markers` section of the configuration file raise errors
```