### PR TITLE
Lint only project files

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ def fmt_check(s: Session) -> None:
 
 @session(venv_backend="none")
 def lint(s: Session) -> None:
-    s.run("flake8")
+    s.run("flake8", "docs", "src", "tests", "noxfile.py")
 
 
 @session(venv_backend="none")


### PR DESCRIPTION
If Python files unrelated to the project get put into the project directory, they get linted and lots of errors appear. For example, setting `virtualenvs.in-project = true` will cause Poetry to create `.venv` at the root of the project. This PR changes `lint` to work like `type_check` and tells flake8 to only lint the project files. It is unclear if `docs` should be linted, but it does contain one Python file.