### PR TITLE
Disable Ruff `I` configuration split-on-trailing-comma

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ src = ["src"]
 
 [tool.ruff.isort]
 force-sort-within-sections = true
+split-on-trailing-comma = false
 # For non-src directory projects, explicitly set top level package names:
 # known-first-party = ["my-app"]
 


### PR DESCRIPTION
Ensure that Ruff `I` rules fold imports when possible, even if there is a trailing comma.

```py
from a import (
    b,
)
```

```py
from a import b
```

See some discussion at

- https://github.com/charliermarsh/ruff/issues/4561
- https://github.com/charliermarsh/ruff/issues/4153