### PR TITLE
Enable W on ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ strict = true
 line-length = 99
 target-version = "py38"
 extend-select = [
+    "W", # pycodestyle
     "I", # isort
     "N", # pep8-naming
     "UP", # pyupgrade


### PR DESCRIPTION
This used to be enabled when the project used flake8, but was lost in the migration to ruff because pycodestyle warnings are not enabled by default in ruff like they are in flake8.