### PR TITLE
Use `select` for Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,9 @@ src = ["src"]
 # To exclude additional folders, use extend-exclude.
 
 [tool.ruff.lint]
-extend-select = [
+select = [
+    "F", # pyflakes
+    "E", # pycodestyle
     "I", # isort
     "N", # pep8-naming
     "UP", # pyupgrade


### PR DESCRIPTION
This is the recommended way to configure Ruff.

- https://docs.astral.sh/ruff/tutorial/#rule-selection

This also includes some checks (such as line length) that overlap with the formatter, but the formatter does not format in all situations (long comments or docstrings) so this allows the linter to fail so that the user can go fix these issues.