### PR TITLE
Ignore `ISC001` Ruff lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,8 @@ select = [
     "SIM", # flake8-simplify
     "TID", # flake8-tidy-imports
 ]
-extend-ignore = ["RUF005", "RUF012"]
+# TODO: Remove ISC001 ignore when formatter updated: https://github.com/astral-sh/ruff/issues/8272
+extend-ignore = ["RUF005", "RUF012", "ISC001"]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true


### PR DESCRIPTION
Suppress `ISC001` until the Ruff formatter is fixed upstream to avoid a warning printed during formatting

- https://github.com/astral-sh/ruff/issues/8272
- https://github.com/astral-sh/ruff/issues/9457