### PR TITLE
Update Ruff target-version to 3.9

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List
 
 import nox
 from nox import parametrize
@@ -42,7 +41,7 @@ def fmt(s: Session) -> None:
         ["ruff", "format", "--check", "."],
     ],
 )
-def lint(s: Session, command: List[str]) -> None:
+def lint(s: Session, command: list[str]) -> None:
     s.run(*command)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ enable_error_code = ["explicit-override"]
 
 [tool.ruff]
 line-length = 99
-target-version = "py38"
+# TODO: Remove this when migrating to [project] requires-python field.
+target-version = "py39"
 src = ["src"]
 # Ruff will automatically exclude all files listed in .gitignore as well as common temporary Python
 # tool directories.


### PR DESCRIPTION
Fix oversight in

- #240

Add `TODO` to remove this redundant field when moving to the standard `[project]` table in either Poetry 2.0 or uv.

- https://docs.astral.sh/ruff/settings/#target-version