### PR TITLE
Avoid deleting unused imports on save within the editor

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,9 +28,27 @@ def test(s: Session) -> None:
 # For some sessions, set venv_backend="none" to simply execute scripts within the existing Poetry
 # environment. This requires that nox is run within `poetry shell` or using `poetry run nox ...`.
 @session(venv_backend="none")
-def fmt(s: Session) -> None:
-    s.run("ruff", "check", ".", "--select", "I", "--fix")
-    s.run("ruff", "format", ".")
+@parametrize(
+    "command",
+    [
+        # During formatting, additionally sort imports and remove unused imports.
+        [
+            "ruff",
+            "check",
+            ".",
+            "--select",
+            "I",
+            "--select",
+            "F401",
+            "--extend-fixable",
+            "F401",
+            "--fix",
+        ],
+        ["ruff", "format", "."],
+    ],
+)
+def fmt(s: Session, command: list[str]) -> None:
+    s.run(*command)
 
 
 @session(venv_backend="none")
@@ -47,7 +65,7 @@ def lint(s: Session, command: list[str]) -> None:
 
 @session(venv_backend="none")
 def lint_fix(s: Session) -> None:
-    s.run("ruff", "check", ".", "--fix")
+    s.run("ruff", "check", ".", "--extend-fixable", "F401", "--fix")
 
 
 @session(venv_backend="none")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,15 @@ select = [
     "SIM", # flake8-simplify
     "TID", # flake8-tidy-imports
 ]
-extend-ignore = ["RUF005", "RUF012"]
+extend-ignore = [
+    "RUF005",
+    "RUF012",
+]
+unfixable = [
+    # Disable unused import fixing by default and only enable in `nox -s fmt` so editors don't
+    # delete unnused imports while in the middle of editing a file on save.
+    "F401",
+]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,8 @@ extend-ignore = [
     "RUF012",
 ]
 unfixable = [
-    # Disable unused import fixing by default and only enable in `nox -s fmt` so editors don't
-    # delete unnused imports while in the middle of editing a file on save.
+    # Disable removing unused imports by default and only enable within nox so editors don't delete
+    # unnused imports while the user is in the middle of editing a file on save.
     "F401",
 ]
 


### PR DESCRIPTION
Disable `F401` outside of `nox` to avoid unused imports from being deleted in the middle of the user editing a file

- https://docs.astral.sh/ruff/settings/#lint_unfixable