### PR TITLE
Uncomment `tool.coverage.report` settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,10 @@ branch = true
 
 # To globally exclude additional code blocks from code coverage reporting, see:
 # https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
-#[tool.coverage.report]
-#exclude_also = [
-#    "if TYPE_CHECKING:",
-#    "raise NotImplementedError",
-#]
+[tool.coverage.report]
+exclude_also = [
+    "case _ as unreachable",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@abstractmethod",
+]


### PR DESCRIPTION
Make this section easier to read/use by default by uncommenting it.