### PR TITLE
Simplify pytest invocation within noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,16 +16,7 @@ def test(s: Session) -> None:
         f"--python={s.virtualenv.location}",
         env={"UV_PROJECT_ENVIRONMENT": s.virtualenv.location},
     )
-    s.run(
-        "python",
-        "-m",
-        "pytest",
-        "--cov=fact",
-        "--cov-report=html",
-        "--cov-report=term",
-        "tests",
-        *s.posargs,
-    )
+    s.run("pytest", "--cov=fact", "--cov-report=html", "--cov-report=term", "tests", *s.posargs)
 
 
 # For some sessions, set venv_backend="none" to simply execute scripts within the existing


### PR DESCRIPTION
`options.error_on_external_run = True` protects us from accidently picking up the incorrect `pytest` and this matches how we are already calling `ruff`, `mypy`, `mkdocs`, etc.