### PR TITLE
Migrate to `pip-licenses-cli`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -108,14 +108,7 @@ def licenses(s: Session) -> None:
         "--locked",
         "--no-default-groups",
         "--no-install-project",
-        f"--python={s.virtualenv.location}",
-        env={"UV_PROJECT_ENVIRONMENT": s.virtualenv.location},
-    )
-    s.run_install(
-        "uv",
-        "pip",
-        "install",
-        "pip-licenses",
+        "--group=licenses",
         f"--python={s.virtualenv.location}",
         env={"UV_PROJECT_ENVIRONMENT": s.virtualenv.location},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ docs = [
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
 ]
+licenses = [
+    "pip-licenses-cli",
+]
 
 [build-system]
 # TODO: Replace this with uv_build when it is it released for GA.

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+licenses = [
+    { name = "pip-licenses-cli" },
+]
 lint = [
     { name = "ruff" },
 ]
@@ -326,6 +329,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extras = ["python"] },
 ]
+licenses = [{ name = "pip-licenses-cli" }]
 lint = [{ name = "ruff" }]
 nox = [{ name = "nox" }]
 test = [
@@ -781,6 +785,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pip-licenses-cli"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip-licenses-lib" },
+    { name = "prettytable" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/6c/b096386c5627dede8106553cb6a5239bb40d6cde7dc5a9cb0bd7f712ee8e/pip_licenses_cli-1.0.0.tar.gz", hash = "sha256:78bc99f7858ad8edf44979e61a012a651ba24d3ed40dced95c24a27969998b6d", size = 23311, upload-time = "2025-05-16T06:37:01.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/47/00d681dcfd4d9f7a65fd71402262c66b63ee860059e5d1423d4054e7fccc/pip_licenses_cli-1.0.0-py3-none-any.whl", hash = "sha256:e46e0c49e8b3547bc40b77c65f1942f63dad35888cb643ecd3fab6c100093429", size = 18092, upload-time = "2025-05-16T06:37:00.528Z" },
+]
+
+[[package]]
+name = "pip-licenses-lib"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/2d/073c1f2eab13376c91ea35dff462d133d5b79d09ad08aba5c1ff9502de23/pip_licenses_lib-0.5.0.tar.gz", hash = "sha256:3e1afbd230703d38baf01fc3b05727d79dfa4ab8877ee305574df1fd73504dab", size = 12581, upload-time = "2025-01-07T11:24:34.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/c1/938df45b41ec5a98261b3ea3d953748c8990198c4b43c39f5a36d020bc2e/pip_licenses_lib-0.5.0-py3-none-any.whl", hash = "sha256:b6b3c1c85a71879494d0ea65f63f3b4ca37cf8e1862617e3766a8402d1064a1d", size = 8642, upload-time = "2025-01-07T11:24:32.776Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -796,6 +823,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b1/85e18ac92afd08c533603e3393977b6bc1443043115a47bb094f3b98f94f/prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57", size = 66276, upload-time = "2025-03-24T19:39:04.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c7/5613524e606ea1688b3bdbf48aa64bafb6d0a4ac3750274c43b6158a390f/prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa", size = 33863, upload-time = "2025-03-24T19:39:02.359Z" },
 ]
 
 [[package]]
@@ -1146,6 +1185,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #276 

`pip-licenses` is no longer maintained, so migrate to the maintained fork, `pip-licenses-cli`

- https://github.com/raimon49/pip-licenses/issues/227#issuecomment-2885810102