### PR TITLE
Fix CLI unit test on Windows

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 
 def test_main() -> None:
@@ -6,7 +7,7 @@ def test_main() -> None:
 
     # Run the CLI command
     result = subprocess.run(
-        ["python", "-m", "fact.cli", "5"],
+        [sys.executable, "-m", "fact.cli", "5"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
Using `python` in a subprocess is not reliable on all platforms. Specifically this fails on Windows. Fix the unit test and use a universal path to the interpreter.