### PR TITLE
Update to `nox-uv` 0.6.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -104,6 +104,6 @@ def docs_github_pages(s: Session) -> None:
 
 
 # Install only main dependencies for the license report.
-@session(uv_groups=["licenses"])
+@session(uv_groups=["licenses"], uv_no_install_project=True)
 def licenses(s: Session) -> None:
     s.run("pip-licenses", *s.posargs)

--- a/uv.lock
+++ b/uv.lock
@@ -787,14 +787,14 @@ wheels = [
 
 [[package]]
 name = "nox-uv"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nox" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/27/01ec5d2cb316ba35cd9b9edbf2d6bad3e3e9db9baad71664b2e6abcfc26e/nox_uv-0.5.0.tar.gz", hash = "sha256:6e58b51712bb49a0799bc88bbca808031ab996431158fd021965d661c1d99fa9", size = 49889, upload-time = "2025-06-08T19:50:58.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/e7/4af4799a4605ad88c0c2a6c2a4b2824e9ec3f7e9844b6e1b273720cc7d72/nox_uv-0.6.0.tar.gz", hash = "sha256:90252c081814c9dee3aa6368d6a3f507a2aa1b35860b83236817061ffd735013", size = 50047, upload-time = "2025-06-10T12:29:44.344Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/76/1875fe0113ae42dfa43b600e5fd31bad8be21c60118bcc4d36b4134a2742/nox_uv-0.5.0-py3-none-any.whl", hash = "sha256:18ea51059504797be16487f3804b5b5f4c507368dfad35ed13e2810cf343c651", size = 4858, upload-time = "2025-06-08T19:50:57.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/02/249f9c2ee2e66ee356035152473abfb3e5d8902bb6fa27c099f170284872/nox_uv-0.6.0-py3-none-any.whl", hash = "sha256:30fe71b19ba87b7041b412c22e742bf0e7cd242d03db01bf22ef443ace193bd4", size = 4907, upload-time = "2025-06-10T12:29:42.93Z" },
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1030,9 +1030,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Avoid installing the package itself into the virtual environment that checks licenses, as the license output is designed to output _dependency_ licenses.
