### PR TITLE
Update to PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ description = "Example Python project using best practices"
 authors = [
     { name = "John Hagen", email = "johnthagen@users.noreply.github.com" }]
 license = "MIT"
+license-files = ["LICENSE*"]
 readme = "README.md"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Remove deprecated trove classifier license and migrate to new PEP 639 license metadata.

- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
- https://hugovk.dev/blog/2025/improving-licence-metadata/
- https://github.com/astral-sh/uv/pull/9442