### PR TITLE
Update to Click 8.4.0, fixing MkDocs live reload compat

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -100,9 +100,7 @@ def docs_offline(s: Session) -> None:
 
 @session(venv_backend="none")
 def docs_serve(s: Session) -> None:
-    # TODO: Remove --livereload when Click bug is fixed upstream:
-    #   https://github.com/squidfunk/mkdocs-material/issues/8478
-    s.run("mkdocs", "serve", "--livereload", env=doc_env)
+    s.run("mkdocs", "serve", env=doc_env)
 
 
 @session(venv_backend="none")

--- a/uv.lock
+++ b/uv.lock
@@ -222,14 +222,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update to Click 8.4.0 to fix the following related issues where `--livereload` is not set on `mkdocs serve` by default

- https://github.com/pallets/click/issues/3403
- https://github.com/squidfunk/mkdocs-material/issues/8478
- https://github.com/mkdocs/mkdocs/issues/4032