### PR TITLE
Fix two typos: "soley" and "neccessary"

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ On Windows, remove the `-S` from the shebang and execute the script using the `p
 ## Package Dependency Tree
 
 `uv tree` is a command for listing installed packages in the form of a dependency tree. For large
-projects, it is often difficult to determine dependency relationships soley from manually
+projects, it is often difficult to determine dependency relationships solely from manually
 inspecting `uv.lock`.
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
     "mkdocs-material",
     "mkdocs-htmlproofer-plugin",
 
-    # Python API documentation (not neccessary for applications).
+    # Python API documentation (not necessary for applications).
     "mkdocstrings[python]",
     # Autodoc.
     "mkdocs-api-autonav",


### PR DESCRIPTION
## Summary

Fix two spelling mistakes found while reading the project:

- `README.md` (Package Dependency Tree section): `soley` → `solely`
- `pyproject.toml` (docs dependency group comment): `neccessary` → `necessary`

## How verified

Confirmed both changes with `grep` on the original files. No functional code is changed — these are comment and prose fixes only.