### PR TITLE
Simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,4 @@
-.idea
-.mypy_cache
-.nox
-.pytest_cache
-dist
-build
-htmlcov
-site
-__pycache__
-*.pyc
-*.egg-info
-.coverage
-.coverage.*
+.idea/
+site/
+__pycache__/
+.coverage*


### PR DESCRIPTION
Remove `.gitignore` entries that either no longer apply (for old build tools like `setuptools`) or are not needed as the tools making the folders already put a `.gitignore` inside the generated folders.