### PR TITLE
Remove `ignore_missing_imports` Mypy setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ default-groups = "all"
 #package = false
 
 [tool.mypy]
-ignore_missing_imports = true
 strict = true
 enable_error_code = ["deprecated", "exhaustive-match", "explicit-override"]
 allow_redefinition = true


### PR DESCRIPTION
Remove `ignore_missing_imports` Mypy setting.

This setting used to be pragmatically important in the days when most Python packages didn't have type hints, but that is now the minority. Leaving this setting on can mask real errors, such as missing dependencies not available for import.